### PR TITLE
Add Map Only Layout

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,11 @@
     "author": "Ozone",
     "variants": {
         "standard": {
-            "display_name": "Map Tracker",
+            "display_name": "Map + Item Tracker",
+            "flags": ["ap"]
+        },
+		"var_maponly": {
+            "display_name": "Map Only (Items in Broadcast View)",
             "flags": ["ap"]
         }
     },

--- a/var_maponly/layouts/tracker.json
+++ b/var_maponly/layouts/tracker.json
@@ -1,0 +1,19 @@
+﻿{
+    "tracker_default": {
+        "type": "container",
+        "background": "#000000",
+        "content": {
+            "type": "dock",
+            "dropshadow": true,
+            "content": [
+                {
+                    "type": "dock",
+                    "content": {
+                        "type": "layout",
+                        "key": "tabbed_maps"
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Adds an alternate layout that displays the map only. Leaves the broadcast view intact for item tracking.